### PR TITLE
Release for v0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [v0.0.15](https://github.com/pyama86/pachanger/compare/v0.0.14...v0.0.15) - 2025-01-29
+
 ## [v0.0.14](https://github.com/pyama86/pachanger/compare/v0.0.13...v0.0.14) - 2025-01-28
 
 ## [v0.0.13](https://github.com/pyama86/pachanger/compare/v0.0.12...v0.0.13) - 2025-01-28

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "0.0.14"
+var Version = "0.0.15"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
This pull request is for the next release as v0.0.15 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.15 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.14" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->



**Full Changelog**: https://github.com/pyama86/pachanger/compare/v0.0.14...v0.0.15