### PR TITLE
Release for v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v0.1.1](https://github.com/pyama86/pachanger/compare/v0.1.0...v0.1.1) - 2025-03-27
+- 構造体を移行できるようにした by @pyama86 in https://github.com/pyama86/pachanger/pull/39
+- Bump golang.org/x/sync from 0.10.0 to 0.11.0 by @dependabot in https://github.com/pyama86/pachanger/pull/37
+- fix lint by @pyama86 in https://github.com/pyama86/pachanger/pull/41
+- Bump golang.org/x/tools from 0.29.0 to 0.30.0 by @dependabot in https://github.com/pyama86/pachanger/pull/44
+- Bump github.com/spf13/cobra from 1.8.1 to 1.9.1 by @dependabot in https://github.com/pyama86/pachanger/pull/45
+- 必要なメソッドや変数をexposeする by @pyama86 in https://github.com/pyama86/pachanger/pull/49
+- Bump golang.org/x/sync from 0.11.0 to 0.12.0 by @dependabot in https://github.com/pyama86/pachanger/pull/52
+- Bump golang.org/x/tools from 0.30.0 to 0.31.0 by @dependabot in https://github.com/pyama86/pachanger/pull/50
+- Bump golang.org/x/text from 0.22.0 to 0.23.0 by @dependabot in https://github.com/pyama86/pachanger/pull/51
+
 ## [v0.0.22](https://github.com/pyama86/pachanger/compare/v0.1.0...v0.0.22) - 2025-03-26
 
 ## [v0.0.22](https://github.com/pyama86/pachanger/compare/v0.1.0...v0.0.22) - 2025-03-18

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "0.1.0"
+var Version = "0.1.1"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
This pull request is for the next release as v0.1.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* 構造体を移行できるようにした by @pyama86 in https://github.com/pyama86/pachanger/pull/39
* Bump golang.org/x/sync from 0.10.0 to 0.11.0 by @dependabot in https://github.com/pyama86/pachanger/pull/37
* fix lint by @pyama86 in https://github.com/pyama86/pachanger/pull/41
* Bump golang.org/x/tools from 0.29.0 to 0.30.0 by @dependabot in https://github.com/pyama86/pachanger/pull/44
* Bump github.com/spf13/cobra from 1.8.1 to 1.9.1 by @dependabot in https://github.com/pyama86/pachanger/pull/45
* 必要なメソッドや変数をexposeする by @pyama86 in https://github.com/pyama86/pachanger/pull/49
* Bump golang.org/x/sync from 0.11.0 to 0.12.0 by @dependabot in https://github.com/pyama86/pachanger/pull/52
* Bump golang.org/x/tools from 0.30.0 to 0.31.0 by @dependabot in https://github.com/pyama86/pachanger/pull/50
* Bump golang.org/x/text from 0.22.0 to 0.23.0 by @dependabot in https://github.com/pyama86/pachanger/pull/51

## New Contributors
* @dependabot made their first contribution in https://github.com/pyama86/pachanger/pull/37

**Full Changelog**: https://github.com/pyama86/pachanger/compare/v0.1.0...v0.1.1