### PR TITLE
Release for v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.1.2](https://github.com/pyama86/pachanger/compare/v0.1.1...v0.1.2) - 2025-04-20
+- Bump golang.org/x/tools from 0.31.0 to 0.32.0 by @dependabot in https://github.com/pyama86/pachanger/pull/62
+- Bump golang.org/x/text from 0.23.0 to 0.24.0 by @dependabot in https://github.com/pyama86/pachanger/pull/61
+
 ## [v0.1.1](https://github.com/pyama86/pachanger/compare/v0.1.0...v0.1.1) - 2025-03-27
 - 構造体を移行できるようにした by @pyama86 in https://github.com/pyama86/pachanger/pull/39
 - Bump golang.org/x/sync from 0.10.0 to 0.11.0 by @dependabot in https://github.com/pyama86/pachanger/pull/37

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "0.1.1"
+var Version = "0.1.2"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
This pull request is for the next release as v0.1.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Bump golang.org/x/tools from 0.31.0 to 0.32.0 by @dependabot in https://github.com/pyama86/pachanger/pull/62
* Bump golang.org/x/text from 0.23.0 to 0.24.0 by @dependabot in https://github.com/pyama86/pachanger/pull/61


**Full Changelog**: https://github.com/pyama86/pachanger/compare/v0.1.1...v0.1.2