### PR TITLE
Release for v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v0.1.5](https://github.com/pyama86/pachanger/compare/v0.1.4...v0.1.5) - 2025-06-11
+- Bump golang.org/x/mod from 0.24.0 to 0.25.0 by @dependabot in https://github.com/pyama86/pachanger/pull/72
+- Bump golang.org/x/sync from 0.13.0 to 0.15.0 by @dependabot in https://github.com/pyama86/pachanger/pull/71
+- Bump golang.org/x/tools from 0.32.0 to 0.34.0 by @dependabot in https://github.com/pyama86/pachanger/pull/70
+- Bump golang.org/x/text from 0.24.0 to 0.26.0 by @dependabot in https://github.com/pyama86/pachanger/pull/69
+
 ## [v0.1.4](https://github.com/pyama86/pachanger/compare/v0.1.3...v0.1.4) - 2025-04-21
 
 ## [v0.1.3](https://github.com/pyama86/pachanger/compare/v0.1.2...v0.1.3) - 2025-04-21

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "0.1.4"
+var Version = "0.1.5"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
This pull request is for the next release as v0.1.5 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.5 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.4" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Bump golang.org/x/mod from 0.24.0 to 0.25.0 by @dependabot in https://github.com/pyama86/pachanger/pull/72
* Bump golang.org/x/sync from 0.13.0 to 0.15.0 by @dependabot in https://github.com/pyama86/pachanger/pull/71
* Bump golang.org/x/tools from 0.32.0 to 0.34.0 by @dependabot in https://github.com/pyama86/pachanger/pull/70
* Bump golang.org/x/text from 0.24.0 to 0.26.0 by @dependabot in https://github.com/pyama86/pachanger/pull/69


**Full Changelog**: https://github.com/pyama86/pachanger/compare/v0.1.4...v0.1.5