### PR TITLE
機能(エイリアス処理): エイリアスimportのサポートを追加

### DIFF
--- a/internal/pachanger/testdata/example/alias_input.go
+++ b/internal/pachanger/testdata/example/alias_input.go
@@ -1,0 +1,13 @@
+package example
+
+import (
+	some_example "github.com/pyama86/pachanger/internal/pachanger/testdata/example"
+)
+
+// TestAliasAccess はエイリアスでアクセスするテスト
+func TestAliasAccess() some_example.SomeExample {
+	return some_example.SomeExample{
+		ID:   1,
+		Note: "test",
+	}
+}

--- a/internal/pachanger/testdata/expected/alias_input_expected.go
+++ b/internal/pachanger/testdata/expected/alias_input_expected.go
@@ -1,0 +1,13 @@
+package example
+
+import (
+	"github.com/pyama86/pachanger/internal/pachanger/testdata/output/changed_example"
+)
+
+// TestAliasAccess はエイリアスでアクセスするテスト
+func TestAliasAccess() changed_example.SomeExample {
+	return changed_example.SomeExample{
+		ID:   1,
+		Note: "test",
+	}
+}

--- a/internal/pachanger/transform_test.go
+++ b/internal/pachanger/transform_test.go
@@ -85,6 +85,29 @@ func TestTransformOtherFile(t *testing.T) {
 	targetPath := filepath.Join(workDir, "example/target_ok.go")
 	targetOutputPath := filepath.Join(workDir, "output/changed_example/target_ok.go")
 
+	// エイリアスimportのテスト
+	t.Run("エイリアス", func(t *testing.T) {
+		inputPath := filepath.Join(workDir, "example/alias_input.go")
+		expectedPath := filepath.Join(workDir, "expected/alias_input_expected.go")
+		outputPath := filepath.Join(workDir, "output/example/alias_input.go")
+		os.Remove(outputPath)
+
+		transformer, err := pachanger.NewTransformer(workDir, "changed_example", "", "", nil)
+		assert.NoError(t, err)
+
+		err = transformer.TransformSymbolsInTargetFile(targetPath, targetOutputPath)
+		assert.NoError(t, err)
+
+		err = transformer.TransformSymbolsInOtherFile(inputPath, outputPath)
+		assert.NoError(t, err)
+		err = transformer.Dump()
+		assert.NoError(t, err)
+
+		diff, err := compareFiles(outputPath, expectedPath)
+		assert.NoError(t, err)
+		assert.Empty(t, diff, fmt.Sprintf("Diff:\n%s", diff))
+	})
+
 	// 同じパッケージの他のファイルが変換されるパターン
 	t.Run("変更前のパッケージと同じパッケージだが別のファイルを処理したケース", func(t *testing.T) {
 		inputPath := filepath.Join(workDir, "example/other_example.go")


### PR DESCRIPTION
エイリアスimportを処理するための機能を追加。エイリアス情報を収集し、古いパッケージを指すエイリアスを新しいパッケージに更新する。テストケースも追加し、エイリアスimportの変換が正しく行われることを確認。