### PR TITLE
Release for v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.1.7](https://github.com/pyama86/pachanger/compare/v0.1.6...v0.1.7) - 2025-08-14
+- Bump golang.org/x/text from 0.26.0 to 0.28.0 by @dependabot[bot] in https://github.com/pyama86/pachanger/pull/82
+
 ## [v0.1.6](https://github.com/pyama86/pachanger/compare/v0.1.5...v0.1.6) - 2025-08-10
 - 機能(エイリアス処理): エイリアスimportのサポートを追加 by @pyama86 in https://github.com/pyama86/pachanger/pull/78
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var Version = "0.1.6"
+var Version = "0.1.7"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
This pull request is for the next release as v0.1.7 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.7 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.6" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Bump golang.org/x/text from 0.26.0 to 0.28.0 by @dependabot[bot] in https://github.com/pyama86/pachanger/pull/82


**Full Changelog**: https://github.com/pyama86/pachanger/compare/v0.1.6...v0.1.7